### PR TITLE
Add id option

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Parameter   | Default    | Type    | Description
 `stroke`    | `0.1`      | Float   | Width of the border around each pixel. Note that each pixel is a 10x10 box, so a stroke of 1 means it will take 10% of the box. Higher values generate more overlap between the pixels.
 `jitter`    | `0`        | Float   | A value between 0 and 1 representing the chance for a pixel to be dislocated by half of its size in a random direction.
 `background`| `#fff`     | String  | A named SVG color string (`blue`, `yellow` etc.) or RGB color (for example `#dddddd`).
+`id`        | `icodi`    | String  | The ID to assign the SVG object. Normally this should not matter, but if you intend to embed this icon in an HTML, or in another SVG, this can be useful.
 `template`  | `:default` | Symbol/String | SVG template to use. Can be `:default`, `:html` or a path to a file. Read more on [Victor SVG Templates].
 
 ---

--- a/lib/icodi.rb
+++ b/lib/icodi.rb
@@ -9,13 +9,13 @@ class Icodi < Victor::SVGBase
 
   attr_reader :text, :options
 
-  def initialize(text = nil, options = {})
-    text, options = nil, text if text.is_a? Hash
+  def initialize(text = nil, opts = {})
+    text, opts = nil, text if text.is_a? Hash
     
     @text = text
-    @options = default_options.merge options
+    @options = default_options.merge opts
 
-    super template: template, viewBox: "0 0 #{size} #{size}", clip_path: "url(#rect)"
+    super template: template, viewBox: "0 0 #{size} #{size}", id: id
     
     generate
   end
@@ -23,9 +23,11 @@ class Icodi < Victor::SVGBase
 private
 
   def generate
+    clip_path_id = "#{id}-#{random_id}"
+
     element :rect, x: 0, y: 0, width: size, height: size, fill: background
     element :defs do
-      element :clipPath, id: :clipper do
+      element :clipPath, id: clip_path_id do
         element :rect, width: size, height: size
       end
     end
@@ -34,7 +36,7 @@ private
     x = mirror_x? ? half : pixels
     y = mirror_y? ? half : pixels
 
-    element :g, clip_path: "url(#clipper)" do
+    element :g, clip_path: "url(##{clip_path_id})" do
       draw x, y
     end
   end  
@@ -88,4 +90,7 @@ private
     pixels - 1 - value
   end
 
+  def random_id
+    random(:nonvisual).rand(9999999)
+  end
 end

--- a/lib/icodi/option_handling.rb
+++ b/lib/icodi/option_handling.rb
@@ -18,6 +18,7 @@ module IcodiCore
         color: random_color,
         mirror: :x,
         jitter: 0,
+        id: :icodi,
       }
     end
 

--- a/spec/fixtures/render1
+++ b/spec/fixtures/render1
@@ -1,10 +1,10 @@
 <rect x="0" y="0" width="50" height="50" fill="#fff"/>
 <defs>
-<clipPath id="clipper">
+<clipPath id="icodi-6753444">
 <rect width="50" height="50"/>
 </clipPath>
 </defs>
-<g clip-path="url(#clipper)">
+<g clip-path="url(#icodi-6753444)">
 <rect x="10" y="0" width="10" height="10" fill="#8ef8be" style="stroke:#8ef8be; stroke-width:0.1"/>
 <rect x="30" y="0" width="10" height="10" fill="#8ef8be" style="stroke:#8ef8be; stroke-width:0.1"/>
 <rect x="20" y="0" width="10" height="10" fill="#8ef8be" style="stroke:#8ef8be; stroke-width:0.1"/>

--- a/spec/fixtures/render1
+++ b/spec/fixtures/render1
@@ -1,21 +1,20 @@
 <rect x="0" y="0" width="50" height="50" fill="#fff"/>
 <defs>
-<clipPath id="icodi-6753444">
+<clipPath id="icodi-8125001">
 <rect width="50" height="50"/>
 </clipPath>
 </defs>
-<g clip-path="url(#icodi-6753444)">
-<rect x="10" y="0" width="10" height="10" fill="#8ef8be" style="stroke:#8ef8be; stroke-width:0.1"/>
-<rect x="30" y="0" width="10" height="10" fill="#8ef8be" style="stroke:#8ef8be; stroke-width:0.1"/>
-<rect x="20" y="0" width="10" height="10" fill="#8ef8be" style="stroke:#8ef8be; stroke-width:0.1"/>
-<rect x="10" y="10" width="10" height="10" fill="#8ef8be" style="stroke:#8ef8be; stroke-width:0.1"/>
-<rect x="30" y="10" width="10" height="10" fill="#8ef8be" style="stroke:#8ef8be; stroke-width:0.1"/>
-<rect x="20" y="10" width="10" height="10" fill="#8ef8be" style="stroke:#8ef8be; stroke-width:0.1"/>
-<rect x="20" y="15.0" width="10" height="10" fill="#8ef8be" style="stroke:#8ef8be; stroke-width:0.1"/>
-<rect x="0" y="30" width="10" height="10" fill="#8ef8be" style="stroke:#8ef8be; stroke-width:0.1"/>
-<rect x="40" y="30" width="10" height="10" fill="#8ef8be" style="stroke:#8ef8be; stroke-width:0.1"/>
-<rect x="15.0" y="35.0" width="10" height="10" fill="#8ef8be" style="stroke:#8ef8be; stroke-width:0.1"/>
-<rect x="25.0" y="35.0" width="10" height="10" fill="#8ef8be" style="stroke:#8ef8be; stroke-width:0.1"/>
-<rect x="0" y="40" width="10" height="10" fill="#8ef8be" style="stroke:#8ef8be; stroke-width:0.1"/>
-<rect x="40" y="40" width="10" height="10" fill="#8ef8be" style="stroke:#8ef8be; stroke-width:0.1"/>
+<g clip-path="url(#icodi-8125001)">
+<rect x="0" y="0" width="10" height="10" fill="#60f29a" style="stroke:#60f29a; stroke-width:0.1"/>
+<rect x="40" y="0" width="10" height="10" fill="#60f29a" style="stroke:#60f29a; stroke-width:0.1"/>
+<rect x="10" y="0" width="10" height="10" fill="#60f29a" style="stroke:#60f29a; stroke-width:0.1"/>
+<rect x="30" y="0" width="10" height="10" fill="#60f29a" style="stroke:#60f29a; stroke-width:0.1"/>
+<rect x="0" y="10" width="10" height="10" fill="#60f29a" style="stroke:#60f29a; stroke-width:0.1"/>
+<rect x="40" y="10" width="10" height="10" fill="#60f29a" style="stroke:#60f29a; stroke-width:0.1"/>
+<rect x="10" y="10" width="10" height="10" fill="#60f29a" style="stroke:#60f29a; stroke-width:0.1"/>
+<rect x="30" y="10" width="10" height="10" fill="#60f29a" style="stroke:#60f29a; stroke-width:0.1"/>
+<rect x="20" y="10" width="10" height="10" fill="#60f29a" style="stroke:#60f29a; stroke-width:0.1"/>
+<rect x="20" y="30" width="10" height="10" fill="#60f29a" style="stroke:#60f29a; stroke-width:0.1"/>
+<rect x="10" y="40" width="10" height="10" fill="#60f29a" style="stroke:#60f29a; stroke-width:0.1"/>
+<rect x="30" y="40" width="10" height="10" fill="#60f29a" style="stroke:#60f29a; stroke-width:0.1"/>
 </g>

--- a/spec/fixtures/render2
+++ b/spec/fixtures/render2
@@ -1,0 +1,20 @@
+<rect x="0" y="0" width="40" height="40" fill="black"/>
+<defs>
+<clipPath id="test-8125001">
+<rect width="40" height="40"/>
+</clipPath>
+</defs>
+<g clip-path="url(#test-8125001)">
+<rect x="-5.0" y="5.0" width="10" height="10" fill="#faa" style="stroke:#faa; stroke-width:3"/>
+<rect x="35.0" y="5.0" width="10" height="10" fill="#faa" style="stroke:#faa; stroke-width:3"/>
+<rect x="-5.0" y="25.0" width="10" height="10" fill="#faa" style="stroke:#faa; stroke-width:3"/>
+<rect x="35.0" y="25.0" width="10" height="10" fill="#faa" style="stroke:#faa; stroke-width:3"/>
+<rect x="10" y="0" width="10" height="10" fill="#faa" style="stroke:#faa; stroke-width:3"/>
+<rect x="20" y="0" width="10" height="10" fill="#faa" style="stroke:#faa; stroke-width:3"/>
+<rect x="10" y="30" width="10" height="10" fill="#faa" style="stroke:#faa; stroke-width:3"/>
+<rect x="20" y="30" width="10" height="10" fill="#faa" style="stroke:#faa; stroke-width:3"/>
+<rect x="5.0" y="15.0" width="10" height="10" fill="#faa" style="stroke:#faa; stroke-width:3"/>
+<rect x="25.0" y="15.0" width="10" height="10" fill="#faa" style="stroke:#faa; stroke-width:3"/>
+<rect x="5.0" y="15.0" width="10" height="10" fill="#faa" style="stroke:#faa; stroke-width:3"/>
+<rect x="25.0" y="15.0" width="10" height="10" fill="#faa" style="stroke:#faa; stroke-width:3"/>
+</g>

--- a/spec/icodi/icodi_spec.rb
+++ b/spec/icodi/icodi_spec.rb
@@ -1,11 +1,24 @@
 require 'spec_helper'
 
 describe Icodi do
+  let(:text) { "some text" }
+  let(:options) { {} }  
+  subject { described_class.new text, options }
+
   context "given a string" do
-    subject { described_class.new "thanks victor", jitter: 0.3 }
-    
     it "generates consistent svg" do
       expect(subject.to_s).to match_fixture 'render1'
+    end
+  end
+
+  context "given all the options" do
+    let(:options) {{ 
+      id: 'test', pixels: 4, mirror: :both, color: '#faa', density: 0.6, 
+      stroke: 3, jitter: 0.5, background: 'black' 
+    }}
+    
+    it "works" do
+      expect(subject.to_s).to match_fixture 'render2'
     end
   end
 end


### PR DESCRIPTION
Before this PR, the clip path received a static ID, which caused a problem when trying to merge several icodi icons with different sizes into one SVG or embed them inside an HTML document.

This PR adds the option to specify ID explicitly. When provided, the exact ID will be used as the ID of teh SVG element, and a random number will be added to the ID of the clip path.